### PR TITLE
Make button texts editable on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ RNNumberPickerLibrary.createDialog(
     minValue: 0,
     maxValue: 100,
     selectedValue: 10,
-    doneText: "Done", // only for Android
+    doneText: "Done",
     doneTextColor: "#000000", // only for Android
-    cancelText: "Cancel", // only for Android
+    cancelText: "Cancel",
     cancelTextColor: "#000000" // only for Android
   },
   (error, data) => {

--- a/ios/RNNumberPickerLibrary.m
+++ b/ios/RNNumberPickerLibrary.m
@@ -16,9 +16,9 @@ RCT_EXPORT_METHOD(createDialog:(NSDictionary *)indic createDialog:(RCTResponseSe
     int maxValue=[indic[@"maxValue"] intValue];
     onDoneClick = doneCallback;
     onCancelClick = cancelCallback;
-    //  NSString *doneText=indic[@"doneText"];
+    NSString *doneText = indic[@"doneText"];
     //  NSString *doneTextColor=indic[@"doneTextColor"];
-    //  NSString *cancelText=indic[@"cancelText"];
+    NSString *cancelText = indic[@"cancelText"];
     //  NSString *cancelTextColor=indic[@"cancelTextColor"];
     
     qtyArray = [[NSMutableArray alloc] init];
@@ -35,6 +35,15 @@ RCT_EXPORT_METHOD(createDialog:(NSDictionary *)indic createDialog:(RCTResponseSe
     }
     
     ActionSheetStringPicker* qtyPicker = [[ActionSheetStringPicker alloc]initWithTitle:@"" rows:qtyArray initialSelection:selectedValue target:self successAction:@selector(didSelectValue:element:) cancelAction:@selector(cancelActionSheet:) origin:self];
+    
+    if (doneText) {
+        [qtyPicker setDoneButton:[[UIBarButtonItem alloc] initWithTitle:doneText style:UIBarButtonItemStylePlain target:nil action:nil]];
+    }
+    
+    if (cancelText) {
+        [qtyPicker setCancelButton:[[UIBarButtonItem alloc] initWithTitle:cancelText style:UIBarButtonItemStylePlain target:nil action:nil]];
+    }
+    
     dispatch_async(dispatch_get_main_queue(), ^{
         [qtyPicker showActionSheetPicker];
     });


### PR DESCRIPTION
Button texts should be editable on iOS too. I checked documentation here https://github.com/skywinder/ActionSheetPicker-3.0/blob/master/BASIC-USAGE.md#want-custom-buttons-view-ok to see how to change button texts with ActionSheetPicker 🔥

If you release this then the new version number should be bumped from `1.0.8` to `1.1.0` since this is minor update because only new stuff was added without breaking anything